### PR TITLE
Adjust documentation copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ export const Signup = () => (
 
 ### Props
 
-- `name: string`: LocalStorage key to save form state to
-- `ignoreValues:? string[]`: Provide array of keys if you need to do not persist some values
+- `name: string`: LocalStorage key to save form state to.
+- `ignoreValues:? string[]`: Provide array of keys if you need to do not persist some values.
 - `debounce:? number`: Default is `300`. Number of ms to debounce the function that saves form state.
-- `storage:? 'localStorage' | 'sessionStorage' | Storage`: default is `localStorage` . Send if you want Session storage or your own storage instead of Local storage
-- `persistInvalid:? boolean`: default is `false` . Persist if you want to save invalid values
+- `storage:? 'localStorage' | 'sessionStorage' | Storage`: default is `localStorage` . Send if you want Session storage or your own storage instead of Local storage.
+- `persistInvalid:? boolean`: default is `false` . Persist if you want to save values while the form is invalid.
 - `hashInitials:? boolean`: default is `false` . Hash initials values to prevent conflict between initialValues and persistedValues.
 - `hashSpecificity:? number`: default is `7` . Hash initials values specificity to prevent conflict between cache hashes.
 


### PR DESCRIPTION
My team and I are using your library to save our Formik fields, we had some difficulties understanding the Prop `persistInvalid`, we thought that this prop would save only valid fields, but we noticed that it will save only when the form is Valid, so based on the code I decided to open this PR to change the documentation to be more clear about that prop.